### PR TITLE
Django 1.10 update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,23 @@ language: python
 
 sudo: false
 
+
 env:
-  - TOX_ENV=py27-django16
-  - TOX_ENV=py27-django17
   - TOX_ENV=py27-django18
-  - TOX_ENV=py33-django17
+  - TOX_ENV=py27-django19
+  - TOX_ENV=py27-django110a1
   - TOX_ENV=py33-django18
-  - TOX_ENV=py34-django17
+  - TOX_ENV=py33-django19
+  - TOX_ENV=py33-django110a1
   - TOX_ENV=py34-django18
-  - TOX_ENV=pypy-django17
+  - TOX_ENV=py34-django19
+  - TOX_ENV=py34-django110a1
   - TOX_ENV=pypy-django18
-  - TOX_ENV=pypy3-django17
+  - TOX_ENV=pypy-django19
+  - TOX_ENV=pypy-django110a1
   - TOX_ENV=pypy3-django18
+  - TOX_ENV=pypy3-django19
+  - TOX_ENV=pypy3-django110a1
 
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ env:
   - TOX_ENV=py27-django19
   - TOX_ENV=py27-django110a1
   - TOX_ENV=py33-django18
-  - TOX_ENV=py33-django19
-  - TOX_ENV=py33-django110a1
   - TOX_ENV=py34-django18
   - TOX_ENV=py34-django19
   - TOX_ENV=py34-django110a1
@@ -17,8 +15,6 @@ env:
   - TOX_ENV=pypy-django19
   - TOX_ENV=pypy-django110a1
   - TOX_ENV=pypy3-django18
-  - TOX_ENV=pypy3-django19
-  - TOX_ENV=pypy3-django110a1
 
 
 install:

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "future>=0.14.3",
+        "django>=1.8"
     ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
 envlist = py27-django{18,19,110a1},
-          py{32,33,34}-django{18,19,110a1}
+		  py{33}-django{1.8}
+          py{34}-django{18,19,110a1}
           pypy-django{18,19,110a1}
-          pypy3-django{18,19,110a1}
+          pypy3-django{18}
 
 [testenv]
 changedir = {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27-django{16,17,18},
-          py{32,33,34}-django{17,18}
-          pypy-django{17,18}
-          pypy3-django{17,18}
+envlist = py27-django{18,19,110a1},
+          py{32,33,34}-django{18,19,110a1}
+          pypy-django{18,19,110a1}
+          pypy3-django{18,19,110a1}
 
 [testenv]
 changedir = {toxinidir}/tests
@@ -11,8 +11,6 @@ commands =
   python runtests.py
 
 deps =
-    django14: Django>=1.4, <1.5
-    django15: Django>=1.5, <1.6
-    django16: Django>=1.6, <1.7
-    django17: Django>=1.7, <1.8
-    django18: Django==1.8b1
+    django18: Django>=1.8, <1.9
+    django19: Django>=1.9, <1.10
+    django110a1: Django==1.10a1


### PR DESCRIPTION
I did the following:
- Removed the `VersionField` dependency on `SubfieldBase` because it has been removed in Django 1.10
- Removed support for Django<=1.8 because they have reached end of support status
- Removed test environments for Django<=1.8
- Added test environments for Django 1.9, 1.10
- Added explicit dependency on Django>=1.8 in the `setup.py`
- Removed tests for unsupported python versions
